### PR TITLE
fix : AuditorAwareImpl에서 UserDetailsImpl 캐스팅 오류 해결

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/global/config/AuditorAwareImpl.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/global/config/AuditorAwareImpl.java
@@ -1,6 +1,7 @@
 package com.sparta.goatgam.global.config;
 
 import com.sparta.goatgam.global.security.UserDetailsImpl;
+import lombok.NonNull;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -8,13 +9,19 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 
 public class AuditorAwareImpl implements AuditorAware<String> {
+    @NonNull
     @Override
     public Optional<String> getCurrentAuditor() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        if (auth == null || !auth.isAuthenticated()){
+        if (auth == null || !auth.isAuthenticated()) {
             return Optional.of("SYSTEM");
         }
-        return Optional.of(((UserDetailsImpl) auth.getPrincipal()).getUser().getNickname());
+
+        if (auth.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            return Optional.of(userDetails.getUser().getNickname());
+        }
+
+        return Optional.of("SYSTEM");
     }
 }


### PR DESCRIPTION
close #47

#### [원인]
1. 회원가입 과정에서 Auditing에 의해 created_by에 넣는 값을 SecurityContext에서 가져옴.
2. 해당 시점에는 로그인이 아직 되지 않았으므로 AuditorAwareImpl에서 principal이 anonymousUser가 됨.
2. UserDetailsImpl로 캐스팅하면 캐스팅 오류가 발생함.

#### [해결 방법]
1. principal이 UserDetailsImpl의 인스턴스일때만 닉네임을 가져오도록 분기 설정
2. anonymousUser일때는 "SYSTEM"을 return함.