### PR TITLE
menu_details 기능 구현 완료

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodRepository.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodRepository.java
@@ -3,8 +3,9 @@ package com.sparta.goatgam.domain.owner.repository;
 import com.sparta.goatgam.domain.owner.entity.Food;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface FoodRepository extends JpaRepository<Food, UUID> {
-
+    Optional<Food> findByIdAndRestaurant_RestaurantId(UUID foodId, UUID restaurantId);
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/controller/RestaurantController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/controller/RestaurantController.java
@@ -1,6 +1,7 @@
 package com.sparta.goatgam.domain.restaurant.controller;
 
 import com.sparta.goatgam.domain.restaurant.dto.RestaurantDetailDto;
+import com.sparta.goatgam.domain.restaurant.dto.RestaurantFoodDetailDto;
 import com.sparta.goatgam.domain.restaurant.dto.RestaurantInfoDto;
 import com.sparta.goatgam.domain.restaurant.dto.RestaurantRequestDto;
 import com.sparta.goatgam.domain.restaurant.service.RestaurantService;
@@ -55,10 +56,13 @@ public class RestaurantController {
     // 특정 식당의 특정 메뉴 조회하기
     // api/v1/restaurant/{restaurantId}/menu?keyword=
 
+
     //특정 식당 메뉴 상세보기
-    // ~~반점 -> 짬뽕 클릭 ->  짬뽕 상세정보 조회
-    // -> 메뉴 상세정보 조회하기
-    //api/v1/restaurant/{restaurant_id}/menu/{menu_id}
+    @Operation(summary = "특정 식당 메뉴 상세보기 ", description = "특정 식당의 메뉴를 상세조회합니다.")
+    @GetMapping("/{restaurantId}/menu/{foodId}")
+    public ResponseEntity<RestaurantFoodDetailDto> getFoodDetail(@PathVariable UUID restaurantId, @PathVariable UUID foodId) {
+        return ResponseEntity.ok(restaurantService.getFoodDetail(restaurantId,foodId));
+    }
 
     //특정 메뉴의 모든 옵션을 조회하기 ->
     //해당 메뉴의 옵션 조회하기

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/dto/RestaurantDetailDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/dto/RestaurantDetailDto.java
@@ -25,8 +25,6 @@ public class RestaurantDetailDto {
     private boolean status;
 
     // 엔티티 -> DTO 변환
-    //진현 수정 10/04
-    //Restaurant의 값은 null일 수 없음
     public static RestaurantDetailDto from(Restaurant r) {
         return RestaurantDetailDto.builder()
                 .restaurantId(r.getRestaurantId())

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/dto/RestaurantFoodDetailDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/dto/RestaurantFoodDetailDto.java
@@ -1,0 +1,30 @@
+package com.sparta.goatgam.domain.restaurant.dto;
+
+import com.sparta.goatgam.domain.owner.entity.Food;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class RestaurantFoodDetailDto {
+    private UUID foodId;
+    private String foodName;
+    private String foodExplain;
+    private int foodPrice;
+    private String foodStatus;
+    private String restaurantName;
+
+    public static RestaurantFoodDetailDto convertDto(Food food) {
+        return new RestaurantFoodDetailDto(
+                food.getId(),
+                food.getFoodName(),
+                food.getFoodExplain(),
+                food.getFoodPrice(),
+                food.getFoodStatus().toString(),
+                food.getRestaurant().getRestaurantName()
+        );
+    }
+
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/entity/Food.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/entity/Food.java
@@ -1,4 +1,0 @@
-package com.sparta.goatgam.domain.restaurant.entity;
-
-public class Food {
-}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/entity/FoodOption.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/restaurant/entity/FoodOption.java
@@ -1,4 +1,0 @@
-package com.sparta.goatgam.domain.restaurant.entity;
-
-public class FoodOption {
-}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [o] 기능 추가

## ❗️ 관련 이슈 링크
https://github.com/1-6P/goat-gam/issues/26

## 📝 개요
- 특정 메뉴의 상세정보를 볼 수 있는 API입니다.

## 🔁 변경 사항
- Owner/FoodRepository에 메서드가 추가되었습니다. 
- 

## 👀 참고 사항
{
"foodId": "0d9ff1ca-b457-4915-8e05-70617fb31d47",
"foodName": "불고기",
"foodExplain": "한우를 이용한 수라간의 시그니쳐 메뉴.불고기입니다",
"foodPrice": 31000,
"foodStatus": "Ok",
"restaurantName": "수라간"
}

의 형식으로 나오며.

메뉴의 status가 "Ok"가 아닌경우,
"해당 상품은 현재 판매하지 않는 상품입니다" 로 throw 던져놨습니다!

foodRepository 메소드 이름은 JPA가 인식할 수 있도록 지었습니다!

## 👀 기타