### PR TITLE
메뉴, 옵션 중복검사 및 복구

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/entity/FoodOption.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/entity/FoodOption.java
@@ -40,7 +40,7 @@ public class FoodOption extends BaseEntity {
         this.surcharge = foodOptionRequestDto.getSurcharge();
     }
 
-    public void delete() {
-        this.deleted = true;
+    public void changeStatus(boolean status) {
+        this.deleted = status;
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodOptionRepository.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodOptionRepository.java
@@ -1,11 +1,15 @@
 package com.sparta.goatgam.domain.owner.repository;
 
+import com.sparta.goatgam.domain.owner.entity.Food;
 import com.sparta.goatgam.domain.owner.entity.FoodOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface FoodOptionRepository extends JpaRepository<FoodOption, UUID> {
     List<FoodOption> findByFood_IdAndDeletedFalse(UUID foodId);
+
+    Optional<FoodOption> findByFoodAndContents(Food food, String contents);
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodRepository.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/repository/FoodRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.goatgam.domain.owner.repository;
 
 import com.sparta.goatgam.domain.owner.entity.Food;
+import com.sparta.goatgam.domain.restaurant.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.UUID;
 
 public interface FoodRepository extends JpaRepository<Food, UUID> {
     Optional<Food> findByIdAndRestaurant_RestaurantId(UUID foodId, UUID restaurantId);
+
+    Optional<Food> findByRestaurantAndFoodName(Restaurant restaurant, String name);
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/service/FoodOptionService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/service/FoodOptionService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -23,6 +24,20 @@ public class FoodOptionService {
         foodService.validateRestaurantOwner(restaurantId, currentUser);
         Food food = foodService.validateFoodInRestaurant(menuId, restaurantId);
 
+        Optional<FoodOption> existingOptionOpt = foodOptionRepository.findByFoodAndContents(food, foodOptionRequestDto.getContents());
+
+        if (existingOptionOpt.isPresent()) {
+            FoodOption existingOption = existingOptionOpt.get();
+
+            if (!existingOption.isDeleted()) {
+                throw new RuntimeException("이미 존재하는 옵션 이름입니다.");
+            }else{
+                existingOption.changeStatus(false);
+                existingOption.update(foodOptionRequestDto);
+                return new ResultResponseDto("restored success", existingOption.getId());
+            }
+        }
+
         FoodOption foodOption = FoodOption.builder()
                 .contents(foodOptionRequestDto.getContents())
                 .surcharge(foodOptionRequestDto.getSurcharge())
@@ -31,7 +46,7 @@ public class FoodOptionService {
 
         foodOptionRepository.save(foodOption);
 
-        return new ResultResponseDto("success", foodOption.getId());
+        return new ResultResponseDto("create success", foodOption.getId());
     }
 
     @Transactional
@@ -42,7 +57,7 @@ public class FoodOptionService {
 
         foodOption.update(foodOptionRequestDto);
 
-        return new ResultResponseDto("success", foodOption.getId());
+        return new ResultResponseDto("update success", foodOption.getId());
     }
 
     @Transactional
@@ -55,8 +70,8 @@ public class FoodOptionService {
             throw new RuntimeException("이미 삭제된 옵션입니다.");
         }
 
-        foodOption.delete();
+        foodOption.changeStatus(true);
         foodOption.deleted(user.getNickname());
-        return new ResultResponseDto("success", foodOption.getId());
+        return new ResultResponseDto("delete success", foodOption.getId());
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/owner/service/FoodService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/owner/service/FoodService.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -25,6 +26,21 @@ public class FoodService {
     public ResultResponseDto addFood(UUID restaurantId, FoodRequestDto dto, User currentUser) {
         Restaurant restaurant = validateRestaurantOwner(restaurantId, currentUser);
 
+        Optional<Food> existingFoodOpt = foodRepository.findByRestaurantAndFoodName(restaurant, dto.getName());
+
+        if (existingFoodOpt.isPresent()) {
+            Food existingFood = existingFoodOpt.get();
+
+            if (existingFood.getFoodStatus() == FoodStatus.Ok || existingFood.getFoodStatus() == FoodStatus.Hidden) {
+                throw new RuntimeException("이미 존재하는 메뉴 이름입니다.");
+            }
+
+            if (existingFood.getFoodStatus() == FoodStatus.Deleted) {
+                existingFood.update(dto);
+                return new ResultResponseDto("restored success", existingFood.getId());
+            }
+        }
+
         Food food = Food.builder()
                 .foodName(dto.getName())
                 .foodPrice(dto.getPrice())
@@ -35,7 +51,7 @@ public class FoodService {
                 .build();
 
         foodRepository.save(food);
-        return new ResultResponseDto("success", food.getId());
+        return new ResultResponseDto("create success", food.getId());
     }
 
     @Transactional
@@ -44,7 +60,7 @@ public class FoodService {
         Food food = validateFoodInRestaurant(menuId, restaurantId);
 
         food.update(foodRequestDto);
-        return new ResultResponseDto("success", food.getId());
+        return new ResultResponseDto("update success", food.getId());
     }
 
     @Transactional
@@ -55,7 +71,7 @@ public class FoodService {
         food.changeStatus(FoodStatus.Deleted);
         food.deleted(currentUser.getNickname());
 
-        return new ResultResponseDto("success", menuId);
+        return new ResultResponseDto("delete success", menuId);
     }
 
     //음식점 권한 조회


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #69 

## 📝 개요
- 메뉴, 옵션 중복검사 및 복구

## 🔁 변경 사항
- foodOption entity delete -> changestatus로 변경
- food, foodOption의 service에 각각 add에 중복검사를 하고 중복이 있을 시 거절
- 삭제된 객체와 같은 이름의 객체를 다시 만들려하면 새로 만드는 대신 삭제된 객체를 복구하고 dto값에 맞게 update하도록 수정
- 메세지에 수행한 작업을 표시하고 success라고 하도록 수정

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타