### PR TITLE
Feature/18 get order details api

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/order")

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.sparta.goatgam.domain.order.controller;
 
+import com.sparta.goatgam.domain.order.dto.OrderDetailResponseDto;
 import com.sparta.goatgam.domain.order.dto.OrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.service.OrderService;
 import com.sparta.goatgam.global.security.UserDetailsImpl;
@@ -9,11 +10,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -25,9 +26,8 @@ public class OrderController {
     private final OrderService orderService;
 
     @Operation(summary = "내 주문 내역 목록 조회", description = "내 주문 내역 전체 목록을 조회합니다.")
-
     @GetMapping("")
-    public PagedModel<OrderSummaryResponseDto> getMyOrderSummary(
+    public ResponseEntity<PagedModel<OrderSummaryResponseDto>> getMyOrderSummary(
             @Parameter(description = "페이지 번호, 0부터 시작", example = "0")
             @RequestParam int page,
 
@@ -36,6 +36,16 @@ public class OrderController {
 
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        return orderService.getMyOrderSummary(page, size, userDetails.getUser());
+        return ResponseEntity.ok(orderService.getMyOrderSummary(page, size, userDetails.getUser()));
+    }
+
+    @Operation(summary = "주문 내역 상세 조회", description = "주문 내역 단건의 상세 정보를 조회합니다.")
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderDetailResponseDto> getMyOrderDetail(
+            @Parameter(description = "주문 내역 ID")
+            @PathVariable UUID orderId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return ResponseEntity.ok(orderService.getMyOrderDetail(orderId, userDetails.getUser()));
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
@@ -43,9 +43,8 @@ public class OrderController {
     @GetMapping("/{orderId}")
     public ResponseEntity<OrderDetailResponseDto> getMyOrderDetail(
             @Parameter(description = "주문 내역 ID")
-            @PathVariable UUID orderId,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @PathVariable UUID orderId) {
 
-        return ResponseEntity.ok(orderService.getMyOrderDetail(orderId, userDetails.getUser()));
+        return ResponseEntity.ok(orderService.getMyOrderDetail(orderId));
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderDetailResponseDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderDetailResponseDto.java
@@ -1,0 +1,29 @@
+package com.sparta.goatgam.domain.order.dto;
+
+import com.sparta.goatgam.domain.order.entity.Order;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class OrderDetailResponseDto {
+    private UUID orderId;
+    private String restaurantName;
+    private String address;
+    private List<OrderFoodItemDto> foods;
+    private int totalPrice;
+    private LocalDateTime orderTime;
+
+    public OrderDetailResponseDto(Order order) {
+        this.orderId = order.getOrderId();
+        this.restaurantName = order.getRestaurant().getRestaurantName();
+        this.address = order.getAddress();
+        this.foods = order.getOrderFoods().stream().map(OrderFoodItemDto::new).toList();
+        this.totalPrice = order.getTotalPrice();
+        this.orderTime = order.getOrderTime();
+    }
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderFoodItemDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderFoodItemDto.java
@@ -12,12 +12,12 @@ public class OrderFoodItemDto {
     private String foodName;
     private List<String> options;
     private int price;
-    private int count;
+    private int quantity;
 
     public OrderFoodItemDto(OrderFood orderFood) {
         this.foodName = orderFood.getFoodName();
         this.options = orderFood.getOptionList();
         this.price = orderFood.getPrice();
-        this.count = orderFood.getCount();
+        this.quantity = orderFood.getQuantity();
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderFoodItemDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/OrderFoodItemDto.java
@@ -1,0 +1,23 @@
+package com.sparta.goatgam.domain.order.dto;
+
+import com.sparta.goatgam.domain.order.entity.OrderFood;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class OrderFoodItemDto {
+    private String foodName;
+    private List<String> options;
+    private int price;
+    private int count;
+
+    public OrderFoodItemDto(OrderFood orderFood) {
+        this.foodName = orderFood.getFoodName();
+        this.options = orderFood.getOptionList();
+        this.price = orderFood.getPrice();
+        this.count = orderFood.getCount();
+    }
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/Order.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/Order.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class Order extends BaseEntity {
 
     @Id

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/Order.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/Order.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -37,10 +38,10 @@ public class Order extends BaseEntity {
     private LocalDateTime orderTime;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, updatable = false, length = 10)
+    @Column(name = "status", nullable = false, length = 10)
     private StatusEnum status;
 
-    @Column(name = "status_by", nullable = false, updatable = false, length = 50)
+    @Column(name = "status_by", nullable = false, length = 50)
     private String statusBy;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -50,4 +51,7 @@ public class Order extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderFood> orderFoods;
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/OrderFood.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/OrderFood.java
@@ -30,8 +30,8 @@ public class OrderFood extends BaseEntity {
     @Column(name = "option_list", columnDefinition = "jsonb", updatable = false)
     private List<String> optionList;
 
-    @Column(name = "count", nullable = false, updatable = false)
-    private int count;
+    @Column(name = "quantity", nullable = false, updatable = false)
+    private int quantity;
 
     @Column(name = "price", nullable = false, updatable = false)
     private int price;

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/OrderFood.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/entity/OrderFood.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class OrderFood extends BaseEntity {
 
     @Id

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,14 +37,9 @@ public class OrderService {
         return new PagedModel<>(orderSummaryList);
     }
 
-    public OrderDetailResponseDto getMyOrderDetail(UUID orderId, User user) {
+    public OrderDetailResponseDto getMyOrderDetail(UUID orderId) {
         Order order = orderRepository.findById(orderId).orElseThrow(() ->
                 new IllegalArgumentException("존재하지 않는 주문 내역입니다."));
-
-        if (user.getRole().getAuthority().equals("User")
-                && !order.getUser().getUserId().equals(user.getUserId())) {
-            throw new AccessDeniedException("해당 주문 내역 접근 권한이 없습니다.");
-        }
 
         return new OrderDetailResponseDto(order);
     }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -6,7 +6,6 @@ import com.sparta.goatgam.domain.order.entity.Order;
 import com.sparta.goatgam.domain.order.repository.OrderRepository;
 import com.sparta.goatgam.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -1,18 +1,27 @@
 package com.sparta.goatgam.domain.order.service;
 
+import com.sparta.goatgam.domain.order.dto.OrderDetailResponseDto;
 import com.sparta.goatgam.domain.order.dto.OrderSummaryResponseDto;
+import com.sparta.goatgam.domain.order.entity.Order;
 import com.sparta.goatgam.domain.order.repository.OrderRepository;
 import com.sparta.goatgam.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderService {
 
     private final OrderRepository orderRepository;
@@ -27,5 +36,17 @@ public class OrderService {
                 orderRepository.findAllByUser(user, pageable).map(OrderSummaryResponseDto::new);
 
         return new PagedModel<>(orderSummaryList);
+    }
+
+    public OrderDetailResponseDto getMyOrderDetail(UUID orderId, User user) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() ->
+                new IllegalArgumentException("존재하지 않는 주문 내역입니다."));
+
+        if (user.getRole().getAuthority().equals("User")
+                && !order.getUser().getUserId().equals(user.getUserId())) {
+            throw new AccessDeniedException("해당 주문 내역 접근 권한이 없습니다.");
+        }
+
+        return new OrderDetailResponseDto(order);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #18 

## 📝 개요
orderId로 주문 내역 단일 건을 상세 조회하는 api를 구현했습니다.

## 🔁 변경 사항
- 주문 내역을 조회하는 과정에서 Order의 Restaurant가 Lazy로 종속되어있으나 Service에서 restaurant 정보를 가져올때는 이미 트랜잭션이 종료되어 값을 가져올 수 없음. 따라서 OrderService에 Transctional readonly annotation을 추가함.
- Order에 OrderFood 양방향 참조를 추가함. Order에서 바로 OrderFood 조회 및 수정, 삭제 가능.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타