### PR TITLE
feat : 관리자용 주문 내역 조회 api 구현

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.sparta.goatgam.domain.order.controller;
 
+import com.sparta.goatgam.domain.order.dto.AdminOrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.dto.OrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.service.OrderService;
 import com.sparta.goatgam.global.security.UserDetailsImpl;
@@ -42,7 +43,7 @@ public class OrderController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<PagedModel<OrderSummaryResponseDto>> getUserOrderSummary(
+    public ResponseEntity<PagedModel<AdminOrderSummaryResponseDto>> getUserOrderSummary(
             @Parameter(description = "조회할 userId. nullable", schema = @Schema(nullable = true))
             @RequestParam(required = false) Long userId,
 

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/controller/OrderController.java
@@ -5,10 +5,12 @@ import com.sparta.goatgam.domain.order.service.OrderService;
 import com.sparta.goatgam.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +39,19 @@ public class OrderController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return orderService.getMyOrderSummary(page, size, userDetails.getUser());
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<PagedModel<OrderSummaryResponseDto>> getUserOrderSummary(
+            @Parameter(description = "조회할 userId. nullable", schema = @Schema(nullable = true))
+            @RequestParam(required = false) Long userId,
+
+            @Parameter(description = "페이지 번호, 0부터 시작", example = "0")
+            @RequestParam int page,
+
+            @Parameter(description = "한 페이지 내 아이템 개수, 10/30/50 이외의 값은 10으로 고정", example = "10")
+            @RequestParam int size) {
+
+        return ResponseEntity.ok(orderService.getUserOrderSummary(userId, page, size));
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/AdminOrderSummaryResponseDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/dto/AdminOrderSummaryResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.goatgam.domain.order.dto;
+
+import com.sparta.goatgam.domain.order.entity.Order;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class AdminOrderSummaryResponseDto {
+    private Long userId;
+    private UUID orderId;
+    private String restaurantName;
+    private String address;
+    private LocalDateTime orderTime;
+    private int totalPrice;
+
+    public AdminOrderSummaryResponseDto(Order order) {
+        this.userId = order.getUser().getUserId();
+        this.orderId = order.getOrderId();
+        this.restaurantName = order.getRestaurant().getRestaurantName();
+        this.address = order.getAddress();
+        this.orderTime = order.getOrderTime();
+        this.totalPrice = order.getTotalPrice();
+    }
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -3,6 +3,7 @@ package com.sparta.goatgam.domain.order.service;
 import com.sparta.goatgam.domain.order.dto.OrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.repository.OrderRepository;
 import com.sparta.goatgam.domain.user.entity.User;
+import com.sparta.goatgam.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -10,22 +11,47 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderService {
 
+    private final UserRepository userRepository;
     private final OrderRepository orderRepository;
 
     public PagedModel<OrderSummaryResponseDto> getMyOrderSummary(int page, int size, User user) {
-        if (size != 10 && size != 30 && size != 50) size = 10;
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-        Pageable pageable = PageRequest.of(page, size, sort);
+        Pageable pageable = makePageable(page, size);
 
         Page<OrderSummaryResponseDto> orderSummaryList =
                 orderRepository.findAllByUser(user, pageable).map(OrderSummaryResponseDto::new);
 
         return new PagedModel<>(orderSummaryList);
+    }
+
+    public PagedModel<OrderSummaryResponseDto> getUserOrderSummary(Long userId, int page, int size) {
+        Pageable pageable = makePageable(page, size);
+
+        Page<OrderSummaryResponseDto> orderSummaryList;
+
+        if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다. id=" + userId));
+
+            orderSummaryList = orderRepository.findAllByUser(user, pageable).map(OrderSummaryResponseDto::new);
+        } else {
+            orderSummaryList = orderRepository.findAll(pageable).map(OrderSummaryResponseDto::new);
+        }
+
+        return new PagedModel<>(orderSummaryList);
+    }
+
+    private Pageable makePageable(int page, int size) {
+        if (size != 10 && size != 30 && size != 50) size = 10;
+
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+
+        return PageRequest.of(page, size, sort);
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -7,12 +7,14 @@ import com.sparta.goatgam.domain.user.entity.User;
 import com.sparta.goatgam.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.sparta.goatgam.global.util.PageableUtils.makePageable;
+import static com.sparta.goatgam.global.util.PageableUtils.order;
 
 @Service
 @RequiredArgsConstructor
@@ -49,18 +51,5 @@ public class OrderService {
         }
 
         return new PagedModel<>(orderSummaryList);
-    }
-
-
-    private Pageable makePageable(int page, int size, Sort.Order... orders) {
-        if (size != 10 && size != 30 && size != 50) size = 10;
-
-        Sort sort = Sort.by(orders);
-
-        return PageRequest.of(page, size, sort);
-    }
-
-    private Sort.Order order(Sort.Direction direction, String field) {
-        return new Sort.Order(direction, field);
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.sparta.goatgam.domain.order.service;
 
+import com.sparta.goatgam.domain.order.dto.AdminOrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.dto.OrderSummaryResponseDto;
 import com.sparta.goatgam.domain.order.repository.OrderRepository;
 import com.sparta.goatgam.domain.user.entity.User;
@@ -22,7 +23,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     public PagedModel<OrderSummaryResponseDto> getMyOrderSummary(int page, int size, User user) {
-        Pageable pageable = makePageable(page, size);
+        Pageable pageable = makePageable(page, size, order(Sort.Direction.DESC, "createdAt"));
 
         Page<OrderSummaryResponseDto> orderSummaryList =
                 orderRepository.findAllByUser(user, pageable).map(OrderSummaryResponseDto::new);
@@ -30,28 +31,36 @@ public class OrderService {
         return new PagedModel<>(orderSummaryList);
     }
 
-    public PagedModel<OrderSummaryResponseDto> getUserOrderSummary(Long userId, int page, int size) {
-        Pageable pageable = makePageable(page, size);
+    public PagedModel<AdminOrderSummaryResponseDto> getUserOrderSummary(Long userId, int page, int size) {
+        Pageable pageable = makePageable(page, size,
+                order(Sort.Direction.ASC, "userUserId"),
+                order(Sort.Direction.DESC, "createdAt")
+        );
 
-        Page<OrderSummaryResponseDto> orderSummaryList;
+        Page<AdminOrderSummaryResponseDto> orderSummaryList;
 
         if (userId != null) {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다. id=" + userId));
 
-            orderSummaryList = orderRepository.findAllByUser(user, pageable).map(OrderSummaryResponseDto::new);
+            orderSummaryList = orderRepository.findAllByUser(user, pageable).map(AdminOrderSummaryResponseDto::new);
         } else {
-            orderSummaryList = orderRepository.findAll(pageable).map(OrderSummaryResponseDto::new);
+            orderSummaryList = orderRepository.findAll(pageable).map(AdminOrderSummaryResponseDto::new);
         }
 
         return new PagedModel<>(orderSummaryList);
     }
 
-    private Pageable makePageable(int page, int size) {
+
+    private Pageable makePageable(int page, int size, Sort.Order... orders) {
         if (size != 10 && size != 30 && size != 50) size = 10;
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Sort sort = Sort.by(orders);
 
         return PageRequest.of(page, size, sort);
+    }
+
+    private Sort.Order order(Sort.Direction direction, String field) {
+        return new Sort.Order(direction, field);
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/global/util/PageableUtils.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/global/util/PageableUtils.java
@@ -1,0 +1,22 @@
+package com.sparta.goatgam.global.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public final class PageableUtils {
+    private PageableUtils() {
+    }
+
+    public static Pageable makePageable(int page, int size, Sort.Order... orders) {
+        if (size != 10 && size != 30 && size != 50) size = 10;
+
+        Sort sort = Sort.by(orders);
+
+        return PageRequest.of(page, size, sort);
+    }
+
+    public static Sort.Order order(Sort.Direction direction, String field) {
+        return new Sort.Order(direction, field);
+    }
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/global/util/PageableUtils.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/global/util/PageableUtils.java
@@ -8,6 +8,24 @@ public final class PageableUtils {
     private PageableUtils() {
     }
 
+    /**
+     * 페이지네이션을 적용할 때 필요한 PageRequest 객체를 Pageable로 캐스팅하여 return 하는 함수입니다.
+     * <br/>
+     * <br/>
+     * 사용 예시:
+     * <br/>
+     * {@code
+     * Pageable pageable = makePageable(page, size,
+     *                                  order(Sort.Direction.ASC, "userUserId"),
+     *                                  order(Sort.Direction.DESC, "createdAt")
+     *                      );
+     * }
+     *
+     * @param page   현재 페이지 번호입니다. 0부터 시작하는 integer값을 넣어주세요.
+     * @param size   한 페이지 당 item 개수입니다. 10/30/50 옵션이 가능하고 이외의 값은 10으로 처리됩니다.
+     * @param orders 결과값을 정렬할 정렬기준입니다. 가변인자로 여러개의 정렬기준을 적용할 수 있습니다.
+     * @return Pageable로 캐스팅한 PageRequest 객체
+     */
     public static Pageable makePageable(int page, int size, Sort.Order... orders) {
         if (size != 10 && size != 30 && size != 50) size = 10;
 
@@ -16,6 +34,21 @@ public final class PageableUtils {
         return PageRequest.of(page, size, sort);
     }
 
+    /**
+     * makePageable 함수에 parameter로 들어갈 Sort.Order 객체를 생성할 수 있는 함수입니다.
+     * <br/>
+     * <br/>
+     * 사용 예시:
+     * <br/>
+     * {@code
+     * order(Sort.Direction.DESC, "createdAt")
+     * }
+     *
+     * @param direction 정렬 방향입니다. asc, desc 등 방향을 넣어주세요.
+     * @param field     정렬 기준으로 삼을 field입니다. Entity 기준 field 이름을 적어주세요. table field 명 아닙니다! Entity에서 User 객체를 외래키로 참조한다면 User 내부의 field에도 접근할 수 있습니다.
+     * @see Sort.Order
+     * @see Sort.Direction
+     */
     public static Sort.Order order(Sort.Direction direction, String field) {
         return new Sort.Order(direction, field);
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #21 

## 📝 개요
userId로 특정 유저의 주문 내역을 조회하거나 모든 주문 내역을 한번에 조회할 수 있다.

## 🔁 변경 사항
- 페이지네이션 적용 코드 분리

## 👀 참고 사항
- 페이지네이션 적용할 때 생성하는 Pageable 객체를 return하는 함수를 만들었습니다. 페이지네이션 적용하신 분들이나 적용하실 분들은 참고해서 사용해주세요.
    ```
    private Pageable makePageable(int page, int size, Sort.Order... orders) {
        if (size != 10 && size != 30 && size != 50) size = 10;

        Sort sort = Sort.by(orders);

        return PageRequest.of(page, size, sort);
    }

    private Sort.Order order(Sort.Direction direction, String field) {
        return new Sort.Order(direction, field);
    }
    ```

## 👀 기타