### PR TITLE
fix : 장바구니 조회 시, 삭제된 음식 주문 정보와 옵션 주문 정보까지 함께 조회되던 문제 해결

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/entity/Cart.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/entity/Cart.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,7 @@ public class Cart extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @SQLRestriction("is_deleted = false")
     private List<CartFood> cartFoods;
 
     @Column(name = "is_deleted", nullable = false)

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/entity/CartFood.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/entity/CartFood.java
@@ -7,6 +7,7 @@ import com.sparta.goatgam.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class CartFood extends BaseEntity {
     private Cart cart;
 
     @OneToMany(mappedBy = "cartFood", cascade = CascadeType.ALL, orphanRemoval = true)
+    @SQLRestriction("is_deleted = false")
     private List<CartFoodOption> cartFoodOptions;
 
     @Column(name = "is_deleted", nullable = false)

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
@@ -110,6 +110,7 @@ public class CartService {
         Cart cart = cartRepository.findByUserAndIsDeletedFalse(user).orElseThrow(() ->
                 new IllegalArgumentException("생성된 장바구니가 없습니다."));
 
+        // @SQLRestriction 어노테이션으로 인해 삭제된 CartFood와 CartFoodOption은 자동으로 제외됨
         return new CartResponseDto(cart);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #101 

## 📝 개요
- 장바구니 조회 시, repository의 쿼리 메소드로 삭제되지 않은 장바구니는 불러오지만 그 안에 연결된 CartFood와 CartFoodOption은 삭제된 데이터까지 모두 조회가 됨.

## 🔁 변경 사항
- Cart와 CartFood에 각각 @SQLRestriction("is_deleted = false")로 연결 조건을 주어 삭제된 CartFood와 CartFoodOption이 조회되지 않도록 함.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타