### PR TITLE
fix : 새로 만든 장바구니에 음식 추가가 되지 않는 오류 해결

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
@@ -45,7 +45,11 @@ public class CartService {
         ).orElseThrow(() -> new IllegalArgumentException("음식을 찾을 수 없습니다."));
         // 1. 해당 유저가 소유하고 있는 활성화 카드 정보 가져오기.
         // 2. 없으면 새로 생성
-        Cart cart = cartRepository.findByUserAndIsDeletedFalse(user).orElseGet(() -> Cart.create(user, restaurant));
+        Cart cart = cartRepository.findByUserAndIsDeletedFalse(user).orElseGet(() -> {
+            Cart newCart = Cart.create(user, restaurant);
+            cartRepository.save(newCart);
+            return newCart;
+        });
 
         // 3. 있으면 requestDto에서 restaurantId 가져와서 cart의 restaurantId와 비교
         // 4. 있는데 같으면 카트 유지
@@ -71,6 +75,7 @@ public class CartService {
             // 5. 있는데 다르면 카트 삭제 후 새 카트 생성
             cart.delete(user);
             cart = Cart.create(user, restaurant);
+            cartRepository.save(cart);
         }
 
         // 6. 카트에 음식 담기   -> message와 카트 ID return
@@ -92,8 +97,6 @@ public class CartService {
             }
 
         cart.addCartFood(cartFood);
-
-        cartRepository.save(cart);
 
         return new MessageAndIdResponseDto("장바구니에 음식을 성공적으로 담았습니다.", cart.getCartId());
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #105 

## 📝 개요
- 장바구니에 음식을 추가할때, 새로운 식당을 추가하거나 기존에 장바구니가 없던 사용자에게 추가하면 오류가 발생함
  - 원인: Cart.create()로 생성한 장바구니를 db에 저장하지 않고(ID가 생성되지 않음) 이를 외래키로 참조하려고 했기때문에

## 🔁 변경 사항
- 장바구니를 새로 생성하면 바로 저장하도록 코드 변경.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타