### PR TITLE
feat : 장바구니 내 음식 옵션 변경 api 구현

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/controller/CartController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.sparta.goatgam.domain.cart.controller;
 
 import com.sparta.goatgam.domain.cart.dto.CartFoodRequestDto;
+import com.sparta.goatgam.domain.cart.dto.CartFoodUpdateRequestDto;
 import com.sparta.goatgam.domain.cart.dto.CartResponseDto;
 import com.sparta.goatgam.domain.cart.service.CartService;
 import com.sparta.goatgam.global.dto.MessageAndIdResponseDto;
@@ -36,5 +37,14 @@ public class CartController {
     public ResponseEntity<CartResponseDto> getCartInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return ResponseEntity.ok(cartService.getCartInfo(userDetails.getUser()));
+    }
+
+    @Operation(summary = "장바구니에서 옵션 변경", description = "장바구니에 든 음식의 옵션을 변경합니다.")
+    @PatchMapping("")
+    public ResponseEntity<MessageAndIdResponseDto> updateCartFoodOption(
+            @RequestBody CartFoodUpdateRequestDto cartFoodUpdateRequestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.ok(cartService.updateCartFoodOption(cartFoodUpdateRequestDto, userDetails.getUser()));
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/dto/CartFoodUpdateRequestDto.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/dto/CartFoodUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.goatgam.domain.cart.dto;
+
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CartFoodUpdateRequestDto(
+        UUID cartFoodId,
+        @Nullable
+        List<UUID> changeOptionList
+) {
+}

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
@@ -1,6 +1,7 @@
 package com.sparta.goatgam.domain.cart.service;
 
 import com.sparta.goatgam.domain.cart.dto.CartFoodRequestDto;
+import com.sparta.goatgam.domain.cart.dto.CartFoodUpdateRequestDto;
 import com.sparta.goatgam.domain.cart.dto.CartResponseDto;
 import com.sparta.goatgam.domain.cart.entity.Cart;
 import com.sparta.goatgam.domain.cart.entity.CartFood;
@@ -45,7 +46,11 @@ public class CartService {
         ).orElseThrow(() -> new IllegalArgumentException("음식을 찾을 수 없습니다."));
         // 1. 해당 유저가 소유하고 있는 활성화 카드 정보 가져오기.
         // 2. 없으면 새로 생성
-        Cart cart = cartRepository.findByUserAndIsDeletedFalse(user).orElseGet(() -> Cart.create(user, restaurant));
+        Cart cart = cartRepository.findByUserAndIsDeletedFalse(user).orElseGet(() -> {
+            Cart newCart = Cart.create(user, restaurant);
+            cartRepository.save(newCart);
+            return newCart;
+        });
 
         // 3. 있으면 requestDto에서 restaurantId 가져와서 cart의 restaurantId와 비교
         // 4. 있는데 같으면 카트 유지
@@ -71,6 +76,7 @@ public class CartService {
             // 5. 있는데 다르면 카트 삭제 후 새 카트 생성
             cart.delete(user);
             cart = Cart.create(user, restaurant);
+            cartRepository.save(cart);
         }
 
         // 6. 카트에 음식 담기   -> message와 카트 ID return
@@ -93,17 +99,7 @@ public class CartService {
 
         cart.addCartFood(cartFood);
 
-        cartRepository.save(cart);
-
         return new MessageAndIdResponseDto("장바구니에 음식을 성공적으로 담았습니다.", cart.getCartId());
-    }
-
-    private boolean optionEquals(CartFood cartFoodA, List<UUID> optionIdListB) {
-        Set<UUID> optionIdSetA = cartFoodA.getCartFoodOptions().stream().map(o -> o.getFoodOption().getId())
-                .collect(Collectors.toSet());
-        Set<UUID> optionIdSetB = new HashSet<>(Optional.ofNullable(optionIdListB).orElse(List.of()));
-
-        return optionIdSetA.equals(optionIdSetB);
     }
 
     public CartResponseDto getCartInfo(User user) {
@@ -112,5 +108,59 @@ public class CartService {
 
         // @SQLRestriction 어노테이션으로 인해 삭제된 CartFood와 CartFoodOption은 자동으로 제외됨
         return new CartResponseDto(cart);
+    }
+
+    @Transactional
+    public MessageAndIdResponseDto updateCartFoodOption(CartFoodUpdateRequestDto cartFoodUpdateRequestDto, User user) {
+        CartFood cartFood = cartFoodRepository.findById(cartFoodUpdateRequestDto.cartFoodId()).orElseThrow(() ->
+                new IllegalArgumentException("장바구니에 해당 음식이 존재하지 않습니다."));
+
+        ArrayList<UUID> newFoodOptionList;
+        if (cartFoodUpdateRequestDto.changeOptionList() == null)
+            newFoodOptionList = new ArrayList<>();
+        else
+            newFoodOptionList = new ArrayList<>(cartFoodUpdateRequestDto.changeOptionList());
+
+        // 옵션 비교해서 삭제된 옵션 지우고
+        for (CartFoodOption cartFoodOption : cartFood.getCartFoodOptions()) {
+            if (!newFoodOptionList.contains(cartFoodOption.getFoodOption().getId())) {
+                cartFoodOption.delete(user);
+            } else {
+                newFoodOptionList.remove(cartFoodOption.getFoodOption().getId());
+            }
+        }
+
+        // 변경된 음식과 기존 음식 비교해서 같으면 음식 자체를 지우고 qnatity plus
+        for (CartFood cartFoodItem : cartFood.getCart().getCartFoods()) {
+            if (optionEquals(cartFoodItem, cartFoodUpdateRequestDto.changeOptionList())) {
+                cartFood.delete(user);
+                cartFoodItem.setQuantity(cartFoodItem.getQuantity() + cartFood.getQuantity());
+                return new MessageAndIdResponseDto("옵션을 성공적으로 변경했습니다.", cartFood.getCart().getCartId());
+            }
+        }
+
+        // 새 옵션 저장
+        for (UUID foodOptionId : newFoodOptionList) {
+            FoodOption foodOption = foodOptionRepository.findById(foodOptionId).orElseThrow(() ->
+                    new IllegalArgumentException("음식 옵션을 찾을 수 없습니다. foodOptionId: " + foodOptionId));
+
+            if (!foodOption.getFood().getId().equals(cartFood.getFood().getId())) {
+                throw new IllegalArgumentException("이 음식의 옵션이 아닙니다. " +
+                        "foodId: " + cartFood.getFood().getId() + "foodOptionId: " + foodOptionId);
+            }
+
+            CartFoodOption cartFoodOption = CartFoodOption.create(foodOption);
+            cartFood.addCartFoodOption(cartFoodOption);
+        }
+
+        return new MessageAndIdResponseDto("옵션을 성공적으로 변경했습니다.", cartFood.getCart().getCartId());
+    }
+
+    private boolean optionEquals(CartFood cartFoodA, List<UUID> optionIdListB) {
+        Set<UUID> optionIdSetA = cartFoodA.getCartFoodOptions().stream().map(o -> o.getFoodOption().getId())
+                .collect(Collectors.toSet());
+        Set<UUID> optionIdSetB = new HashSet<>(Optional.ofNullable(optionIdListB).orElse(List.of()));
+
+        return optionIdSetA.equals(optionIdSetB);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #79 

## 📝 개요
- 장바구니 내 음식의 옵션을 변경하면 옵션을 비교하여 변경된 옵션을 삭제 및 추가함.
- 최종적으로 변경된 형태가 기존에 추가되어있던 음식과 동일하면 음식을 병합하여 개수를 산정함.

## 🔁 변경 사항
- 변경 사항을 작성해주세요.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타