### PR TITLE
feat : 장바구니 내 음식 삭제 api 구현

### DIFF
--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/controller/CartController.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/controller/CartController.java
@@ -13,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/cart")
@@ -36,5 +38,14 @@ public class CartController {
     public ResponseEntity<CartResponseDto> getCartInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return ResponseEntity.ok(cartService.getCartInfo(userDetails.getUser()));
+    }
+
+    @Operation(summary = "장바구니에서 음식 삭제", description = "장바구니에서 음식을 삭제합니다.")
+    @PatchMapping("{cartFoodId}")
+    public ResponseEntity<MessageAndIdResponseDto> deleteCartFood(
+            @PathVariable UUID cartFoodId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.ok(cartService.deleteCartFood(cartFoodId, userDetails.getUser()));
     }
 }

--- a/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
+++ b/goatgam/src/main/java/com/sparta/goatgam/domain/cart/service/CartService.java
@@ -98,6 +98,19 @@ public class CartService {
         return new MessageAndIdResponseDto("장바구니에 음식을 성공적으로 담았습니다.", cart.getCartId());
     }
 
+    @Transactional
+    public MessageAndIdResponseDto deleteCartFood(UUID cartFoodId, User user) {
+        CartFood cartFood = cartFoodRepository.findById(cartFoodId).orElseThrow(() ->
+                new IllegalArgumentException("장바구니내 음식 정보를 찾을 수 없습니다."));
+
+        if (cartFood.getIsDeleted())
+            throw new IllegalArgumentException("이미 삭제된 음식입니다.");
+
+        cartFood.delete(user);
+
+        return new MessageAndIdResponseDto("성공적으로 삭제되었습니다.", cartFood.getCart().getCartId());
+    }
+
     private boolean optionEquals(CartFood cartFoodA, List<UUID> optionIdListB) {
         Set<UUID> optionIdSetA = cartFoodA.getCartFoodOptions().stream().map(o -> o.getFoodOption().getId())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #78 

## 📝 개요
- 장바구니 내 음식 삭제 api 구현
- 음식이 전부 삭제되어도 장바구니는 삭제 되지 않음.

## 🔁 변경 사항
- 변경 사항을 작성해주세요.

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타